### PR TITLE
Update connectivity list show explore button condition checking 

### DIFF
--- a/src/components/ConnectivityList/ConnectivityList.vue
+++ b/src/components/ConnectivityList/ConnectivityList.vue
@@ -237,6 +237,10 @@ export default {
     },
     // shouldShowExploreButton: Checks if the feature is in the list of available anatomy facets
     shouldShowExploreButton: function (features) {
+      // facetList will not be available when there has no Sidebar's data
+      if (!this.facetList.length) {
+        return true
+      }
       for (let i = 0; i < features.length; i++) {
         if (this.facetList.includes(features[i].name.toLowerCase())) {
           return true

--- a/src/components/DrawToolbar/DrawToolbar.vue
+++ b/src/components/DrawToolbar/DrawToolbar.vue
@@ -573,7 +573,7 @@ export default {
   border-color: var(--el-color-primary-light-5);
   border-radius: 1rem;
   position: absolute;
-  right: 30%;
+  right: 40%;
   bottom: 1rem;
   z-index: 10;
 }

--- a/src/components/DrawToolbar/DrawToolbar.vue
+++ b/src/components/DrawToolbar/DrawToolbar.vue
@@ -573,8 +573,8 @@ export default {
   border-color: var(--el-color-primary-light-5);
   border-radius: 1rem;
   position: absolute;
-  right: calc(50vw - 100px);
-  bottom: 16px;
+  right: 30%;
+  bottom: 1rem;
   z-index: 10;
 }
 


### PR DESCRIPTION
The connectivity list in [flatmapvuer](https://github.com/ddjnw1yu/flatmapvuer/tree/connectivity-explorer-tab-with-multiple-neuron-selection)'s Tooltip will throw a Cypress testing error when the hidden button is clicked. The button shows or hides depending on the data from the Sidebar, and since flatmapvuer alone does not connect to the sidebar yet.

The example of Cypress testing error in [flatmapvuer](https://github.com/ddjnw1yu/flatmapvuer/tree/connectivity-explorer-tab-with-multiple-neuron-selection)

> CypressError: Timed out retrying after 30050ms: `cy.click()` failed because this element is not visible:
> 
> `<button data-v-59976cc1="" aria-disabled="false" type="button" class="el-button button" id="open-dendrites-button" style="display: none;">...</button>`
> 
> This element `<button#open-dendrites-button.el-button.button>` is not visible because it has CSS property: `display: none`

This update has been added to [Connectivity Graph knowledge improvement](https://github.com/ABI-Software/map-utilities/pull/32).